### PR TITLE
Issue 43: Update POM to reflect Maven Central nomenclature

### DIFF
--- a/concurrent/pom.xml
+++ b/concurrent/pom.xml
@@ -6,18 +6,18 @@
 	<parent>
 		<groupId>org.jbrew</groupId>
 		<artifactId>jbrew-parent</artifactId>
-		<version>0.1.0-SNAPSHOT</version>
+		<version>0.1.0-alpha-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>concurrent</artifactId>
 
-	<name>JBrew Concurrency Library</name>
+	<name>JBrew :: Concurrency Library</name>
 	<description>
 		An easy-to-consume concurrency library allowing for "Tasks" to execute business logic in a thread safe manner.
 		This library helps users achieve multi-threading in their applications without needing to control for object 
 		contention in race conditions.
 	</description>
-	<url>jbrew.org</url>
+	<url>https://jbrew.org</url>
 
 	<properties>
 		<sonar.projectKey>org.jbrew:concurrent</sonar.projectKey>

--- a/pom.xml
+++ b/pom.xml
@@ -5,11 +5,12 @@
 	<packaging>pom</packaging>
 	<groupId>org.jbrew</groupId>
 	<artifactId>jbrew-parent</artifactId>
-	<version>0.1.0-SNAPSHOT</version>
+	<version>0.1.0-alpha-SNAPSHOT</version>
 
-	<name>JBrew Parent POM</name>
+	<name>JBrew :: Parent POM</name>
 	<description>
-		The JBrew Java library collection is a set of helper libraries with features ranging from concurrency to sorting! Be sure to check out the documentation at jbrew.org.
+		The JBrew Java library collection is a set of helper libraries with features ranging from concurrency to Swing! The 
+		official documentation is available at jbrew.org.
 	</description>
 	<url>https://jbrew.org</url>
 


### PR DESCRIPTION
closes #43 

This PR updates the url and description tag in the pom.xml for the parent and children to reflect updated information as well as follow Maven Central standards for nomenclature.